### PR TITLE
[PALEP18-164] Prevent creation of monitors without measurement

### DIFF
--- a/bundles/org.palladiosimulator.measurementsui.wizard/src/org/palladiosimulator/measurementsui/wizard/main/StandardSetWizard.java
+++ b/bundles/org.palladiosimulator.measurementsui.wizard/src/org/palladiosimulator/measurementsui/wizard/main/StandardSetWizard.java
@@ -109,13 +109,14 @@ public class StandardSetWizard extends org.eclipse.jface.wizard.Wizard {
             provider.addMetricDescriptionsToAllMonitors(monitors);  
             
             for (Monitor monitor : monitors) {
-
-                editor.addMonitorToRepository(dataApplication.getMonitorRepository(),
-                        monitor);
-                editor.addMeasuringPointToRepository(
-                        dataApplication.getModelAccessor().getMeasuringPointRepositoryList().get(0),
-                        monitor.getMeasuringPoint());
-                editor.setMeasuringPointToMonitor(monitor, monitor.getMeasuringPoint());
+            	if (!monitor.getMeasurementSpecifications().isEmpty()) {
+	                editor.addMonitorToRepository(dataApplication.getMonitorRepository(),
+	                        monitor);
+	                editor.addMeasuringPointToRepository(
+	                        dataApplication.getModelAccessor().getMeasuringPointRepositoryList().get(0),
+	                        monitor.getMeasuringPoint());
+	                editor.setMeasuringPointToMonitor(monitor, monitor.getMeasuringPoint());
+            	}
             }
 
         } else {


### PR DESCRIPTION
It does not make sense to create empty Monitors. Even more, SimuLizar fails if it encouters unsupported MeasuringPoints. As it is not configurable which Measuring Points should be offered to the user, we at least should prevent unsupported ones to be created by default.

See https://jira.palladio-simulator.com/projects/PALEP18/issues/PALEP18-164