### PR TITLE
[PALEP18-163] Removed unsupported metrics from measuring point configuration

### DIFF
--- a/bundles/org.palladiosimulator.measurementsui.extension.contributions/plugin.xml
+++ b/bundles/org.palladiosimulator.measurementsui.extension.contributions/plugin.xml
@@ -18,13 +18,6 @@
             SuggestedMetricDescription="true">
       </client>
       <client
-            ID="org.palladiosimulator.measurementsui.extension.contributions.client4"
-            MeasuringPoint="AssemblyOperationMeasuringPoint"
-            MetricDescription="_6rYmYs7nEeOX_4BzImuHbA"
-            Name="AssemblyOperation with ResponseTime"
-            SuggestedMetricDescription="true">
-      </client>
-      <client
             ID="org.palladiosimulator.measurementsui.extension.contributions.client5"
             MeasuringPoint="ExternalCallActionMeasuringPoint"
             MetricDescription="_6rYmYs7nEeOX_4BzImuHbA"
@@ -39,32 +32,11 @@
             SuggestedMetricDescription="true">
       </client>
       <client
-            ID="org.palladiosimulator.measurementsui.extension.contributions.client7"
-            MeasuringPoint="ResourceContainerMeasuringPoint"
-            MetricDescription="_paDhIs7qEeOX_4BzImuHbA"
-            Name="ResourceContainer with StateOfActiveResource"
-            SuggestedMetricDescription="true">
-      </client>
-      <client
             ID="org.palladiosimulator.measurementsui.extension.contributions.client1"
             MeasuringPoint="ActiveResourceMeasuringPoint"
             MetricDescription="_eg_F0s7qEeOX_4BzImuHbA"
             Name="ActiveResource with ResourceDemand"
             SuggestedMetricDescription="true">
-      </client>
-      <client
-            ID="org.palladiosimulator.measurementsui.extension.contributions.client2"
-            MeasuringPoint="ActiveResourceMeasuringPoint"
-            MetricDescription="_QIb6cikUEeSuf8LV7cHLgA"
-            Name="ActiveResource with UtilizationOfActiveResource"
-            SuggestedMetricDescription="true">
-      </client>
-      <client
-            ID="org.palladiosimulator.measurementsui.extension.contributions.client3"
-            MeasuringPoint="ActiveResourceMeasuringPoint"
-            MetricDescription="_mhws4SkUEeSuf8LV7cHLgA"
-            Name="ActiveResource with UtilizationOfActiveResourceTuple"
-            SuggestedMetricDescription="false">
       </client>
       <client
             ID="org.palladiosimulator.measurementsui.extension.contributions.client4"

--- a/bundles/org.palladiosimulator.measurementsui.extension.contributions/plugin.xml
+++ b/bundles/org.palladiosimulator.measurementsui.extension.contributions/plugin.xml
@@ -21,7 +21,7 @@
             ID="org.palladiosimulator.measurementsui.extension.contributions.client5"
             MeasuringPoint="ExternalCallActionMeasuringPoint"
             MetricDescription="_6rYmYs7nEeOX_4BzImuHbA"
-            Name="ExternallCall with ResponseTime"
+            Name="ExternalCall with ResponseTime"
             SuggestedMetricDescription="true">
       </client>
       <client


### PR DESCRIPTION
Currently, the wizard creates several unsupported monitors, which lead to failing simulations. This PR removes the following metrics:
- State of Active Resource on Resource Containers (does not make sense)
- Response Time on Assembly Operation (currently not supported by SimuLizar) see: https://jira.palladio-simulator.com/projects/PALEP18/issues/PALEP18-163
- Utilization (Tuple) on Active Resource (does not work with FeedThrough, as it is an aggregation over time) see: https://jira.palladio-simulator.com/projects/SIMULIZAR/issues/SIMULIZAR-113

