### PR TITLE
Include SLO bundle into feature.

### DIFF
--- a/features/org.palladiosimulator.measurementsui.feature/feature.xml
+++ b/features/org.palladiosimulator.measurementsui.feature/feature.xml
@@ -68,6 +68,12 @@
          version="0.0.0"
          unpack="false"/>
 	<plugin
+         id="org.palladiosimulator.measurementsui.servicelevelobjectiveview"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+	<plugin
          id="org.palladiosimulator.measurementsui.viewer"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
The new bundle from #187 was not included in the feature. This leads to a failing build of the aggregated update site. In general, all bundles have to be shipped via a feature.

This PR includes the new bundle in the feature.