### PR TITLE
Use new swt chart update site URL.

### DIFF
--- a/releng/org.palladiosimulator.measurementsui.targetplatform/tp.target
+++ b/releng/org.palladiosimulator.measurementsui.targetplatform/tp.target
@@ -207,11 +207,11 @@
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.7.0.201806111355"/>
-<repository location="https://download.eclipse.org/technology/swtbot/releases/2.7.0/"/>
+<repository location="http://download.eclipse.org/technology/swtbot/releases/2.7.0/"/>
 </location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="nightly" includeSource="false" type="InstallableUnit">
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 <unit id="org.eclipse.swtchart" version="0.7.0.201906051446"/>
-<repository location="https://download.eclipse.org/swtchart/0.7.0/update"/>
+<repository location="http://download.eclipse.org/swtchart/releases/0.7.0/update/"/>
 </location>
 </locations>
 </target>


### PR DESCRIPTION
For some reason, the SWTChart project changed their update site location, which breaks the build. I adjusted it to the new URL.